### PR TITLE
fix #13

### DIFF
--- a/src/robertluo/pullable/core.clj
+++ b/src/robertluo/pullable/core.clj
@@ -161,6 +161,10 @@
   (-append [this k v]
     (append this k v))
 
+  Object
+  (-append [this k v]
+    this)
+
   IPersistentMap
   (-append [this k v]
     (append this k v))

--- a/test/robertluo/pullable_test.clj
+++ b/test/robertluo/pullable_test.clj
@@ -79,4 +79,9 @@
   (testing "#10"
     (is (= {:a {:b 1 :c sut/NONE}}
          (sut/pull {:a (fn [x] {:b x})}
-                   {'(:a :with [1]) [:b {:c [:d]}]})))))
+                   {'(:a :with [1]) [:b {:c [:d]}]}))))
+  (testing "#13"
+    (is (= {:f [{:a :robertluo.pullable.core/none}
+                {:a :robertluo.pullable.core/none}]}
+           (sut/pull {:f (constantly {})}
+                     {'(:f :batch [[1] [2]]) [{:a [:b {:c [:d]}]}]})))))


### PR DESCRIPTION
这个问题，应当是在处理`default-transform`、`join-transform`时，只应对appendable的target时才做`-append`操作，但是target本身是可扩展的，可以用`(satisfies? Target  target)`判断是否可以`-append`。但据以往经验，`satisfies? `函数执行效率比较低，在pull数据时高频调用很容易造成性能问题。

因此从另外一个角度考虑，不在transform时处理，交给`-append`处理，`-append`里自行决定如何`append`，包括do nothing。这里，对于不可assoc的Object，`-append`时就不做操作。